### PR TITLE
fix input sequences function when code have a repeated subsequence

### DIFF
--- a/pdf417.js
+++ b/pdf417.js
@@ -595,8 +595,8 @@ var PDF417 = {
 			numseq = [];			
 		} else {
 			// add offset to each matched line
-			for (var n=0;n<numseq.length;n++) {
-				var offset = code.indexOf(numseq[n]);
+			for (var n = 0, offset=0; n < numseq.length; n++, offset++) {
+				offset = code.indexOf(numseq[n], offset);
 				numseq[n] = [numseq[n], offset];
 			}
 		}


### PR DESCRIPTION
function getInputSequences on pdf417.js fail when code has a repeated subsequence. Invalid codes could be:
"PB03C0000005730101[1111111111111;1111111111111;1111111111111;1111111111111]"
"PB03C0000005730101[1111111111111;111111111111X;1111111111112;1111111111111]"
"PB03C0000005730101[1111111111111;111111111111X;1111111111112;111111111111X]"

The problem was calculating the "offset" of the code using indexOf, because it's was necessary to keep a previous reference to get the correct offset.
